### PR TITLE
Add issue templates with auto labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/EDITORIAL_ATTRIBUTION_UPDATE.md
+++ b/.github/ISSUE_TEMPLATE/EDITORIAL_ATTRIBUTION_UPDATE.md
@@ -1,0 +1,25 @@
+---
+name: Editorial Attribution Update
+about: Request updates to author or source attribution for an editorial.
+title: "[Editorial Attribution Update] "
+labels: Editorial Attribution Update
+assignees: utilForever
+---
+
+## Current Attribution
+
+Describe the existing attribution text and where it appears.
+
+## Requested Attribution Update
+
+Provide the exact attribution text that should be used.
+
+## Reason For Update
+
+Explain why the attribution should be changed.
+
+## Supporting Links or Evidence
+
+Share any references that support the request.
+
+Reference: https://editorial.coduck.io/copyright

--- a/.github/ISSUE_TEMPLATE/EDITORIAL_CORRECTION.md
+++ b/.github/ISSUE_TEMPLATE/EDITORIAL_CORRECTION.md
@@ -1,0 +1,25 @@
+---
+name: Editorial Correction
+about: Report mistakes, typos, or inaccuracies in an editorial.
+title: "[Editorial Correction] "
+labels: Editorial Correction
+assignees: utilForever
+---
+
+## Current Editorial Content
+
+Please quote or summarize the part that is incorrect.
+
+## Proposed Correction
+
+Describe what should be changed.
+
+## Why This Is Incorrect
+
+Provide a short explanation and, if possible, supporting evidence.
+
+## Additional Context
+
+Add any extra details that may help maintainers review quickly.
+
+Reference: https://editorial.coduck.io/copyright

--- a/.github/ISSUE_TEMPLATE/EDITORIAL_REMOVAL.md
+++ b/.github/ISSUE_TEMPLATE/EDITORIAL_REMOVAL.md
@@ -1,0 +1,25 @@
+---
+name: Editorial Removal Request
+about: Request removal of an editorial due to ownership or rights concerns.
+title: "[Editorial Removal Request] "
+labels: Editorial Removal
+assignees: utilForever
+---
+
+## Removal Request Details
+
+Describe exactly what content should be removed.
+
+## Reason For Removal
+
+Explain why removal is requested.
+
+## Ownership or Rights Information
+
+Provide evidence of ownership or rights concerns related to this content.
+
+## Additional Context
+
+Include any supporting details or links.
+
+Reference: https://editorial.coduck.io/copyright


### PR DESCRIPTION
## Why
The repository needed structured intake forms for editorial correction, attribution update, and removal requests so maintainers can review copyright-related reports consistently.

## What changed
- Added `.github/ISSUE_TEMPLATE/EDITORIAL_CORRECTION.md` for correction reports.
- Added `.github/ISSUE_TEMPLATE/EDITORIAL_ATTRIBUTION_UPDATE.md` for attribution change requests.
- Added `.github/ISSUE_TEMPLATE/EDITORIAL_REMOVAL.md` for removal requests.
- Set each template to use its corresponding label (`Editorial Correction`, `Editorial Attribution Update`, `Editorial Removal`) and included the reference URL from the issue.

Cloes #5.

## Notes for reviewers
- This is a documentation-only change.
- No existing files were modified outside `.github/ISSUE_TEMPLATE/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added three GitHub issue templates for editorial management: Editorial Correction, Editorial Attribution Update, and Editorial Removal Request. These templates improve the submission experience with standardized forms, auto-configured metadata including appropriate labels and assignees, and comprehensive information collection to ensure all editorial content change requests are properly documented and tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->