### PR TITLE
Add contributing guide for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to cp-editorial-data
+
+Thanks for contributing to cp-editorial-data. This document describes the expected workflow for this repository.
+
+## Getting Started
+
+1. Fork this repository and clone your fork.
+2. Create a branch for your change.
+3. Add or update the relevant editorial PDF file(s).
+4. Confirm the path and filename follow the conventions below.
+5. Open a pull request with a clear description.
+
+## Path and Filename
+
+Use the existing directory hierarchy whenever possible:
+
+`<Category>\<Organization or Series>\<Contest or Season>\<File>.pdf`
+
+Examples from this repository:
+
+- `Petrozavodsk Programming Camp\Summer 2024\Day 1 - Welcome Contest.pdf`
+- `Open Cup\XXI Open Cup named after E.V. Pankratiev\Stage 14 - Grand Prix of Tokyo.pdf`
+
+Guidelines:
+
+- Keep files in the most specific existing folder.
+- Preserve the original contest/event naming style and capitalization.
+- Use `.pdf` for editorial files.
+- Avoid unrelated renames or moves in the same pull request.
+
+## Pull Requests
+
+Before submitting, follow the repository PR checklist in `.github/PULL_REQUEST_TEMPLATE.md`:
+
+- Describe the purpose and scope of your change.
+- Review editorial content for correctness.
+- Confirm links and references are valid (when updated).
+- Include only files related to your change.
+
+If your change is a correction, attribution update, or removal request, you can also open an issue using the templates in `.github/ISSUE_TEMPLATE`.


### PR DESCRIPTION
## Description

This adds a new `CONTRIBUTING.md` so contributors have a clear, repository-specific guide for submitting documentation changes consistently. It addresses issue #7 by documenting how to get started, where files should go, and what reviewers expect in pull requests.

The guide includes:
- a simple fork/branch/edit/PR workflow
- path and filename conventions based on the current directory structure
- pull request guidance aligned with `.github/PULL_REQUEST_TEMPLATE.md`

Closes #7.

## Checklist

- [x] I described the purpose and scope of this PR.
- [x] I reviewed the changed editorial content for correctness.
- [x] I confirmed that links and references are valid (if updated).
- [x] I verified that no unrelated files are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution guidelines with step-by-step instructions for forking, branching, and submitting pull requests
  * Included directory structure and filename conventions with style guidelines for editorial files
  * Provided PR checklist covering scope description, content verification, and link validation requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->